### PR TITLE
windows: Statically link vcruntime DLL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ repository = "https://github.com/FrameworkComputer/qmk_hid"
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 hidapi = "2.2"
+
+[build-dependencies]
+static_vcruntime = "2.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    static_vcruntime::metabuild();
+}


### PR DESCRIPTION
Otherwise it won't run on some freshly installed machines.
Windows complains that `vcruntime140.dll` is missing.
Users would have to install the MSVC C++ Redistributable package.

On a local build of `cargo clean; cargo build --release`:
Size of .exe before: 857 KB
Size of .exe after: 878 KB

Note: Only affects release builds! I think that's because the debug version of this DLL isn't redistributable.