### PR TITLE
qmk_gui: Fix crash on flashing on Chinese language system

### DIFF
--- a/uf2conv.py
+++ b/uf2conv.py
@@ -232,8 +232,10 @@ def to_str(b):
 def get_drives():
     drives = []
     if sys.platform == "win32":
+        # TODO: Could also check "VolumeName" == "RPI-RP2"
+        # But it should be okay because we check for the INFO file that no other drive would have
         r = subprocess.check_output(["wmic", "PATH", "Win32_LogicalDisk",
-                                     "get", "DeviceID,", "VolumeName,",
+                                     "get", "DeviceID,",
                                      "FileSystem,", "DriveType"])
         for line in to_str(r).split('\n'):
             words = re.split('\s+', line)


### PR DESCRIPTION
Would crash in to_str with
'utf-8' code can't decode byte ...

That's because "VolumeName" the volume name would include Chinese characters. They should be decodeable by utf8, so not sure why it happens.
But we don't actually use this in the output.

Also note that the columns aren't orderd the way we ask them, but alphabetically.