### PR TITLE
gh-actions: Build only required project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Rust CI
 on:
   push:
+  paths-ignore:
+    - 'python/**'
 
 jobs:
   # Enable later

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -1,6 +1,8 @@
 name: Python CI
 on:
   push:
+  paths:
+    - 'python/**'
 
 jobs:
   build-gui:


### PR DESCRIPTION
Don't build python if rust was changed and vice-versa.